### PR TITLE
job.pp: Allow to specify the service to require

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,9 @@
 # [*jenkins_url*]
 # The full url (including port) to the jenkins instance.
 #
+# [*service*]
+# The service launching job will require in jenkins_job_builder::job
+#
 #  === Examples
 #
 # Installing jenkins_job_builder to a specified version
@@ -41,7 +44,8 @@ class jenkins_job_builder(
   $user = $jenkins_job_builder::params::user,
   $password = $jenkins_job_builder::params::password,
   $hipchat_token = $jenkins_job_builder::params::hipchat_token,
-  $jenkins_url = $jenkins_job_builder::params::jenkins_url
+  $jenkins_url = $jenkins_job_builder::params::jenkins_url,
+  $service = $jenkins_job_builder::params::service,
 ) inherits jenkins_job_builder::params {
 
   validate_re($::osfamily,'RedHat|Debian',"${::operatingsystem} not supported")

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -52,6 +52,7 @@ define jenkins_job_builder::job (
   exec { "manage jenkins job - ${name}":
     command     => "/bin/sleep ${delay} && jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-${name}.yaml",
     refreshonly => true,
-    require     => Service['jenkins']
+    require     => Service[$jenkins_job_builder::service]
   }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class jenkins_job_builder::params {
   $hipchat_token = ''
   $jenkins_url = 'http://localhost:8080'
   $version = 'latest'
+  $service = 'jenkins'
 
   case $::osfamily {
     'RedHat', 'Amazon': {


### PR DESCRIPTION
Currently, it is supposed that the jenkins package is installed.
But if jenkins is deployed as a war on top of Tomcat or any other
server, the resource `Service[jenkins]` will not exist, hence fail.
