### PR TITLE
jenkins-job-yam: Add the '-job' keyword

### DIFF
--- a/templates/jenkins-job-yaml.erb
+++ b/templates/jenkins-job-yaml.erb
@@ -14,6 +14,7 @@
         obj.each do |element|
           if element.instance_of?(Hash)
             one = element.keys.sort!
+            yaml_string << "\n -job:"
             one.each do |o|
               if nest > 0
                 space = " "*(nest+4)
@@ -29,6 +30,7 @@
         end
       elsif obj.instance_of?(Hash)
         one = obj.keys.sort!
+        yaml_string << "\n -job:"
         one.each do |o|
           yaml_string << "\n" + (" "*(nest+4)) + "#{o}:"
           yaml_string << sort_yaml(obj["#{o}"], nest+1)


### PR DESCRIPTION
Currently, there is not '-job' keyword on the generated yaml file
hence it crashes when it tries to load it.
