### PR TITLE
Added support for just supplying yaml jobs

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -17,6 +17,9 @@
 # [*service_name*]
 # The name of the jenkins service to restart when configuration changes are made
 #
+# [*job_yaml*]
+# Include this content as raw yaml for the job
+#
 #  === Examples
 #
 # Installing jenkins_job_builder::job to configure a job
@@ -48,12 +51,18 @@
 define jenkins_job_builder::job (
   $config = {},
   $delay = 0,
-  $service_name = 'jenkins'
+  $service_name = 'jenkins',
+  $job_yaml = '',
 ) {
 
+  if $config != {} {
+    $content = template('jenkins_job_builder/jenkins-job-yaml.erb')
+  } else {
+    $content = $job_yaml
+  }
   file { "/tmp/jenkins-${name}.yaml":
     ensure  => present,
-    content => template('jenkins_job_builder/jenkins-job-yaml.erb'),
+    content => $content,
     notify  => Exec["manage jenkins job - ${name}"]
   }
 

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -39,5 +39,15 @@ describe 'jenkins_job_builder::job', :type => :define do
 
       it { should contain_file('/tmp/jenkins-test.yaml').with_content(/name:\s+"test"/) }
     end
+    describe 'job yaml' do
+        let(:title) {'test'}
+        let(:params) {{
+            'job_yaml' => "---\n- job:\n    name: \"test\"\n"
+        }}
+        it {
+            should contain_file('/tmp/jenkins-test.yaml').\
+              with_content(/---\n- job:\n    name: "test"\n/m)
+        }
+    end
   end
 end


### PR DESCRIPTION
This should allow you to add jobs that just plain yaml files

Example

``` puppet
jenkins::job::builder {'test':
    $job_yaml => template('module/mymod/test.yml.erb')
}
```

test.yml.erb is

``` yaml

---
- job:
    name: "test"
```
