### PR TITLE
Allow for only using system packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,14 @@
 # [*jenkins_url*]
 # The full url (including port) to the jenkins instance.
 #
+# [*install_from_git*]
+# Boolean, defaults to false. This will install JJB itself from git, but system pkgs will satisfy dependencies.
+# The behavior when install_from_git and install_from_pkg are false is to install from pip
+#
+# [*install_from_pkg*]
+# Boolean, defaults to false. Only allow system packages to satisfy installation sources. Useful for some environments that require this.
+# The behavior when install_from_git and install_from_pkg are false is to install from pip
+#
 #  === Examples
 #
 # Installing jenkins_job_builder to a specified version
@@ -48,6 +56,7 @@ class jenkins_job_builder(
   $jenkins_url      = $jenkins_job_builder::params::jenkins_url,
   $service          = 'jenkins',
   $install_from_git = $jenkins_job_builder::params::install_from_git,
+  $install_from_pkg = $jenkins_job_builder::params::install_from_pkg,
   $git_revision     = $jenkins_job_builder::params::git_revision,
   $git_url          = $jenkins_job_builder::params::git_url,
 
@@ -63,6 +72,11 @@ class jenkins_job_builder(
   validate_string($git_revision)
   validate_string($git_url)
   validate_bool($install_from_git)
+  validate_bool($install_from_pkg)
+
+  if count([$install_from_git, $install_from_pkg], true) > 1 {
+    fail("A single primary install source must be selected for ${name}")
+  }
 
   class {'jenkins_job_builder::install': } ->
   class {'jenkins_job_builder::config': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,11 +5,15 @@
 # == Class jenkins_job_builder::install
 #
 # This class is meant to be called from jenkins_job_builder
-# It installs the pip package and all required dependencies
+# It installs all packages and all required dependencies.
+#
+# You can choose for git, pip, or system pkgs as the primary
+# package source.
 #
 class jenkins_job_builder::install(
   $version          = $jenkins_job_builder::version,
   $install_from_git = $jenkins_job_builder::install_from_git,
+  $install_from_pkg = $jenkins_job_builder::install_from_pkg,
   $git_url          = $jenkins_job_builder::git_url,
   $git_revision     = $jenkins_job_builder::git_revision,
 ) {
@@ -19,7 +23,6 @@ class jenkins_job_builder::install(
   }
 
   ensure_resource('package', $jenkins_job_builder::params::python_packages, { 'ensure' => 'present' })
-  ensure_resource('package', 'pyyaml', { 'ensure' => 'present', 'provider' => 'pip', 'require' => 'Package[python]'})
 
   if $install_from_git {
 
@@ -35,6 +38,12 @@ class jenkins_job_builder::install(
       path        => '/usr/local/bin:/usr/bin:/bin/',
       refreshonly => true,
       subscribe   => Vcsrepo['/opt/jenkins_job_builder'],
+    }
+
+  } elsif $install_from_pkg {
+
+    package { $jenkins_job_builder::params::jjb_packages:
+      ensure => $version,
     }
 
   } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,21 +17,29 @@ class jenkins_job_builder::params {
   $version = 'latest'
   $service = 'jenkins'
   $install_from_git = false
+  $install_from_pip = true
+  $install_from_pkg = false
   $git_revision     = 'master'
   $git_url          = 'https://git.openstack.org/openstack-infra/jenkins-job-builder'
 
   case $::osfamily {
     'RedHat', 'Amazon': {
-      $python_packages = [ 'python', 'python-devel', 'python-pip', 'python-argparse']
+      if $::operatingsystemrelease =~ /^6/ {
+        $python_packages = [ 'python', 'python-devel', 'python-pip', 'python-argparse', 'PyYAML']
+        # This requires the dcaro/jenkins-job-builder repository
+        $jjb_packages    = [ 'jenkins-job-builder']
+      } else {
+        $python_packages = [ 'python', 'python-devel', 'python-pip', 'PyYAML']
+        $jjb_packages    = [ 'python-jenkins-job-builder']
+      }
     }
     debian: {
-      $python_packages = [ 'python', 'python-dev', 'python-pip', 'python-argparse' ]
+      $python_packages = [ 'python', 'python-dev', 'python-pip', 'python-argparse', 'python-yaml' ]
+      $jjb_packages    = [ 'jenkins-job-builder']
     }
     default: {
       fail("${::operatingsystem} not supported")
     }
   }
-
-
 
 }

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -6,7 +6,8 @@ describe 'jenkins_job_builder' do
       describe "jenkins_job_builder class without any parameters on #{osfamily}" do
         let(:params) {{ }}
         let(:facts) {{
-          :osfamily => osfamily,
+          :osfamily               => osfamily,
+          :operatingsystemrelease => '6',
         }}
 
         it { should compile.with_all_deps }
@@ -61,7 +62,8 @@ describe 'jenkins_job_builder' do
     describe "jenkins_job_builder class without any parameters on a 'Debian' OS" do
       let(:params) {{ }}
       let(:facts) {{
-        :osfamily => 'Debian',
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => 'should_not_be_used',
       }}
 
       ['python', 'python-pip', 'python-yaml'].each do |dep|
@@ -101,7 +103,8 @@ describe 'jenkins_job_builder' do
         :install_from_git => true
       }}
       let(:facts) {{
-        :osfamily => 'Debian'
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => 'should_not_be_used',
       }}
 
       it { should contain_vcsrepo('/opt/jenkins_job_builder').with(
@@ -118,7 +121,8 @@ describe 'jenkins_job_builder' do
         :install_from_pkg => true
       }}
       let(:facts) {{
-        :osfamily => 'Debian'
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => 'should_not_be_used',
       }}
 
       it { should contain_package('jenkins-job-builder').with_ensure('latest') }
@@ -153,8 +157,9 @@ describe 'jenkins_job_builder' do
   context 'unsupported operating system' do
     describe 'jenkins_job_builder class without any parameters on Solaris/Nexenta' do
       let(:facts) {{
-        :osfamily        => 'Solaris',
-        :operatingsystem => 'Nexenta',
+        :osfamily               => 'Solaris',
+        :operatingsystem        => 'Nexenta',
+        :operatingsystemrelease => 'should_not_be_used',
       }}
 
       it { expect { should contain_package('jenkins_job_builder') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
@@ -180,7 +185,8 @@ describe 'jenkins_job_builder' do
         }
       }}
       let(:facts) {{
-        :osfamily => 'Debian'
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => 'should_not_be_used',
       }}
 
       it { should contain_file('/tmp/jenkins-test01.yaml').with(

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -64,7 +64,19 @@ describe 'jenkins_job_builder' do
         :osfamily => 'Debian',
       }}
 
-      ['python', 'python-pip', 'pyyaml'].each do |dep|
+      ['python', 'python-pip', 'python-yaml'].each do |dep|
+        it { should contain_package(dep).with_ensure('present') }
+      end
+
+    end
+    describe "jenkins_job_builder class without any parameters on a 'RedHat' OS version 6" do
+      let(:params) {{ }}
+      let(:facts) {{
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+      }}
+
+      ['python', 'python-pip', 'PyYAML', 'python-argparse'].each do |dep|
         it { should contain_package(dep).with_ensure('present') }
       end
 
@@ -72,10 +84,11 @@ describe 'jenkins_job_builder' do
     describe "jenkins_job_builder class without any parameters on a 'RedHat' OS" do
       let(:params) {{ }}
       let(:facts) {{
-        :osfamily => 'RedHat',
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '7',
       }}
 
-      ['python', 'python-pip', 'pyyaml', 'python-argparse'].each do |dep|
+      ['python', 'python-pip', 'PyYAML'].each do |dep|
         it { should contain_package(dep).with_ensure('present') }
       end
 
@@ -99,11 +112,49 @@ describe 'jenkins_job_builder' do
     end
   end
 
+  context 'install from pkg' do
+    describe "jenkins_job_builder installed from pkg on 'Debian' OS" do
+      let(:params) {{
+        :install_from_pkg => true
+      }}
+      let(:facts) {{
+        :osfamily => 'Debian'
+      }}
+
+      it { should contain_package('jenkins-job-builder').with_ensure('latest') }
+
+    end
+    describe "jenkins_job_builder installed from pkg on 'RedHat' OS version el6" do
+      let(:params) {{
+        :install_from_pkg => true
+      }}
+      let(:facts) {{
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+      }}
+
+      it { should contain_package('jenkins-job-builder').with_ensure('latest') }
+
+    end
+    describe "jenkins_job_builder installed from pkg on 'RedHat' OS" do
+      let(:params) {{
+        :install_from_pkg => true
+      }}
+      let(:facts) {{
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '7',
+      }}
+
+      it { should contain_package('python-jenkins-job-builder').with_ensure('latest') }
+
+    end
+  end
+
   context 'unsupported operating system' do
     describe 'jenkins_job_builder class without any parameters on Solaris/Nexenta' do
       let(:facts) {{
         :osfamily        => 'Solaris',
-        :operatingsystem => 'Nexenta'
+        :operatingsystem => 'Nexenta',
       }}
 
       it { expect { should contain_package('jenkins_job_builder') }.to raise_error(Puppet::Error, /Nexenta not supported/) }


### PR DESCRIPTION
I am not totally sure I like this method, but I wanted to try preserving the majority of the existing api.  

Now that I'm writing this I realize that it does break for someone who had $install_from_git set to false before.  Before I go back to try and figure out a better idea on that, what is the consensus on this method?

Also, I went and looked up the PyYAML package names for debian/RH worlds, and just added it to the main ensure package list.  I didnt see any reason why this was done, but doesn't mean there isnt a good reason.

- [x] address not matching previous ```install_from_git = false``` behavior
- [x] needs testing updates


Also... this might Fix #10 #12 #13 #20 