### PR TITLE
CentOS 7 Fix

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,11 +8,11 @@
 # It sets the global ini file used by jenkins_job_builder
 #
 class jenkins_job_builder::config(
-  $jobs = $jenkins_job_builder::jobs,
-  $user = $jenkins_job_builder::user,
-  $password = $jenkins_job_builder::password,
+  $jobs          = $jenkins_job_builder::jobs,
+  $user          = $jenkins_job_builder::user,
+  $password      = $jenkins_job_builder::password,
   $hipchat_token = $jenkins_job_builder::hipchat_token,
-  $jenkins_url = $jenkins_job_builder::jenkins_url
+  $jenkins_url   = $jenkins_job_builder::jenkins_url
 ) {
 
   if $caller_module_name != $module_name {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class jenkins_job_builder(
   $hipchat_token    = $jenkins_job_builder::params::hipchat_token,
   $jenkins_url      = $jenkins_job_builder::params::jenkins_url,
   $service          = 'jenkins',
+  $python_packages  = $jenkins_job_builder::params::python_packages,
   $install_from_git = $jenkins_job_builder::params::install_from_git,
   $git_revision     = $jenkins_job_builder::params::git_revision,
   $git_url          = $jenkins_job_builder::params::git_url,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,8 +18,8 @@ class jenkins_job_builder::install(
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  ensure_resource('package', $jenkins_job_builder::params::python_packages, { 'ensure' => 'present' })
-  ensure_resource('package', 'pyyaml', { 'ensure' => 'present', 'provider' => 'pip', 'require' => 'Package[python]'})
+  ensure_resource('package', $jenkins_job_builder::python_packages, { 'ensure' => 'present' })
+  ensure_resource('package', 'pyyaml', { 'ensure' => 'present', 'provider' => 'pip', 'require' => Package[$jenkins_job_builder::python_packages]})
 
   if $install_from_git {
 

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -49,12 +49,12 @@
 # }
 #
 define jenkins_job_builder::job (
-  $config = {},
-  $delay = 0,
+  $config       = {},
+  $delay        = 0,
   $service_name = 'jenkins',
-  $job_yaml = '',
-  $tries = '5',
-  $try_sleep = '15',
+  $job_yaml     = '',
+  $tries        = '5',
+  $try_sleep    = '15',
 ) {
 
   if $config != {} {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -50,6 +50,7 @@
 #
 define jenkins_job_builder::job (
   $config       = {},
+  $config_mode  = '0640',
   $delay        = 0,
   $service_name = 'jenkins',
   $job_yaml     = '',
@@ -64,6 +65,7 @@ define jenkins_job_builder::job (
   }
   file { "/tmp/jenkins-${name}.yaml":
     ensure  => present,
+    mode    => $config_mode,
     content => $content,
     notify  => Exec["manage jenkins job - ${name}"]
   }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -69,7 +69,8 @@ define jenkins_job_builder::job (
   }
 
   exec { "manage jenkins job - ${name}":
-    command     => "/bin/sleep ${delay} && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-${name}.yaml",
+    command     => "sleep ${delay} && jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-${name}.yaml",
+    path        => '/usr/local/bin:/usr/bin:/bin',
     refreshonly => true,
     tries       => $tries,
     try_sleep   => $try_sleep,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,13 +9,13 @@
 #
 class jenkins_job_builder::params {
 
-  $jobs = {}
-  $user = ''
-  $password = ''
-  $hipchat_token = ''
-  $jenkins_url = 'http://localhost:8080'
-  $version = 'latest'
-  $service = 'jenkins'
+  $jobs             = {}
+  $user             = ''
+  $password         = ''
+  $hipchat_token    = ''
+  $jenkins_url      = 'http://localhost:8080'
+  $version          = 'latest'
+  $service          = 'jenkins'
   $install_from_git = false
   $git_revision     = 'master'
   $git_url          = 'https://git.openstack.org/openstack-infra/jenkins-job-builder'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,11 @@ class jenkins_job_builder::params {
 
   case $::osfamily {
     'RedHat', 'Amazon': {
-      $python_packages = [ 'python', 'python-devel', 'python-pip', 'python-argparse']
+      if $::operatingsystemmajrelease == '7' {
+        $python_packages = [ 'python', 'python-devel', 'python-pip' ]
+      } else {
+        $python_packages = [ 'python', 'python-devel', 'python-pip', 'python-argparse']
+      }
     }
     debian: {
       $python_packages = [ 'python', 'python-dev', 'python-pip', 'python-argparse' ]
@@ -31,7 +35,5 @@ class jenkins_job_builder::params {
       fail("${::operatingsystem} not supported")
     }
   }
-
-
 
 }

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -80,6 +80,19 @@ describe 'jenkins_job_builder' do
       end
 
     end
+    describe "jenkins_job_builder class without any parameters on a 'RedHat/CentOS' 7.x" do
+      let(:params) {{ }}
+      let(:facts) {{
+        :osfamily => 'RedHat',
+        :operatingsystemmajrelease => '7'
+      }}
+
+      ['python', 'python-pip', 'python-devel', 'pyyaml'].each do |dep|
+        it { should contain_package(dep).with_ensure('present') }
+      end
+      it { should_not contain_package('python-argparse') }
+
+    end
   end
 
   context 'install from git' do
@@ -132,12 +145,12 @@ describe 'jenkins_job_builder' do
         :osfamily => 'Debian'
       }}
 
-      it { should contain_file('/tmp/jenkins-test01.yaml').with(
-        'content' => "--- \n  - job: \n      name: test01\n      description: \"the first jenkins job\"\n"
+      it { should contain_file('/tmp/jenkins-test01.yaml').with_content(
+        "--- \n  - job: \n      name: test01\n      description: \"the first jenkins job\"\n"
       )}
 
-      it { should contain_file('/tmp/jenkins-test02.yaml').with(
-        'content' => "--- \n  - job: \n      name: test02\n      description: \"the second jenkins job\"\n"
+      it { should contain_file('/tmp/jenkins-test02.yaml').with_content(
+        "--- \n  - job: \n      name: test02\n      description: \"the second jenkins job\"\n"
       )}
     end
   end

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -11,11 +11,12 @@ describe 'jenkins_job_builder::job', :type => :define do
         it { should contain_file('/tmp/jenkins-test.yaml').with_content('') }
 
         it { should contain_exec('manage jenkins job - test').with(
-          'command' => '/bin/sleep 0 && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml',
+          'command'     => 'sleep 0 && jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml',
+          'path'        => '/usr/local/bin:/usr/bin:/bin',
           'refreshonly' => 'true',
-          'require' => 'Service[jenkins]',
-          'tries' => '5',
-          'try_sleep' => '15'
+          'require'     => 'Service[jenkins]',
+          'tries'       => '5',
+          'try_sleep'   => '15'
         )}
       end
     end
@@ -29,20 +30,20 @@ describe 'jenkins_job_builder::job', :type => :define do
       }}
 
       it { should contain_exec('manage jenkins job - test').with(
-        'command' => '/bin/sleep 5 && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml'
+        'command' => 'sleep 5 && jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml'
       )}
     end
 
     describe 'with retry mechanism' do
       let(:title) { 'test' }
       let(:params) {{
-        'tries' => '10',
+        'tries'     => '10',
         'try_sleep' => '45'
       }}
 
       it { should contain_exec('manage jenkins job - test').with(
-        'command' => '/bin/sleep 0 && /usr/local/bin/jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml',
-        'tries' => '10',
+        'command'   => 'sleep 0 && jenkins-jobs --ignore-cache --conf /etc/jenkins_jobs/jenkins_jobs.ini update /tmp/jenkins-test.yaml',
+        'tries'     => '10',
         'try_sleep' => '45'
       )}
     end
@@ -53,18 +54,18 @@ describe 'jenkins_job_builder::job', :type => :define do
         'config' => { 'name' => 'test' }
       }}
 
-      it { should contain_file('/tmp/jenkins-test.yaml').with(
-        'content' => "--- \n  - job: \n      name: test\n"
+      it { should contain_file('/tmp/jenkins-test.yaml').with_content(
+        "--- \n  - job: \n      name: test\n"
       )}
     end
 
     describe 'job yaml' do
       let(:title) {'test'}
       let(:params) {{
-        'job_yaml' => "--- \n  - job: \n      name: test\n"
+        'job_yaml' => "---\n- job:\n    name: test\n"
       }}
       it { should contain_file('/tmp/jenkins-test.yaml').with(
-        'content' => "--- \n  - job: \n      name: test\n"
+        'content' => "---\n- job:\n    name: test\n"
       )}
     end
   end


### PR DESCRIPTION
Fixes for installation on CentOS 7 and `exec { manage jenkins job` binary path.

Cheers,
Tron