### PR TITLE
Fix the Travis CI build badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Install [jenkins_job_builder](ci.openstack.org/jenkins-job-builder/) to allow you to manage your Jenkins jobs  
 
-[![Build Status](https://secure.travis-ci.org/opentable/puppet-jenkins_job_builder.png)](https://secure.travis-ci.org/opentable/puppet-jenkins_job_builder.png)
+[![Build Status](https://api.travis-ci.org/voxpupuli/puppet-jenkins_job_builder.png)](https://travis-ci.org/voxpupuli/puppet-jenkins_job_builder)
 
 ##Module Description
 


### PR DESCRIPTION
It is currently pointing to the old puppet community name.