### PR TITLE
Add the optional timeout option for the [jenkins] config block.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The user used to authenticate to the Jenkins instance.
 ####`password`
 The password used to authenticate to the Jenkins instance.
 
+#### `timeout`
+(Optional) The connection timeout (in seconds) to the Jenkins server. If `timeout` is unset it will remove any existing timeout values in the config file.
+
 ####`hipchat_token`
 If using the jenkins hipchat plugin, this is the token that should be specified in the global config.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,7 @@ class jenkins_job_builder::config(
   $jobs = $jenkins_job_builder::jobs,
   $user = $jenkins_job_builder::user,
   $password = $jenkins_job_builder::password,
+  $timeout  = $jenkins_job_builder::timeout,
   $hipchat_token = $jenkins_job_builder::hipchat_token,
   $jenkins_url = $jenkins_job_builder::jenkins_url
 ) {
@@ -52,6 +53,21 @@ class jenkins_job_builder::config(
     section => 'jenkins',
     setting => 'url',
     value   => $jenkins_url,
+    require => File['/etc/jenkins_jobs/jenkins_jobs.ini'],
+  }
+
+  if $timeout {
+    $ensure_timeout = 'present'
+  } else {
+    $ensure_timeout = 'absent'
+  }
+
+  ini_setting { 'jenkins-jobs timeout':
+    ensure  => $ensure_timeout,
+    path    => '/etc/jenkins_jobs/jenkins_jobs.ini',
+    section => 'jenkins',
+    setting => 'timeout',
+    value   => $timeout,
     require => File['/etc/jenkins_jobs/jenkins_jobs.ini'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,9 @@
 # [*password*]
 # The password used to authenticate to the Jenkins instance.
 #
+# [*timeout*]
+# The connection timeout (in seconds) to the Jenkins server.
+#
 # [*hipchat_token*]
 # If using the jenkins hipchat plugin, this is the token that should be specified in the global config.
 #
@@ -52,6 +55,7 @@ class jenkins_job_builder(
   $jobs             = $jenkins_job_builder::params::jobs,
   $user             = $jenkins_job_builder::params::user,
   $password         = $jenkins_job_builder::params::password,
+  $timeout          = $jenkins_job_builder::params::timeout,
   $hipchat_token    = $jenkins_job_builder::params::hipchat_token,
   $jenkins_url      = $jenkins_job_builder::params::jenkins_url,
   $service          = 'jenkins',
@@ -78,7 +82,13 @@ class jenkins_job_builder(
     fail("A single primary install source must be selected for ${name}")
   }
 
+  # only validate optional params if they are present
+  if $timeout {
+    validate_integer($timeout)
+  }
+
   class {'::jenkins_job_builder::install': } ->
   class {'::jenkins_job_builder::config': } ->
+
   Class['jenkins_job_builder']
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class jenkins_job_builder::params {
   $jobs = {}
   $user = ''
   $password = ''
+  $timeout = undef
   $hipchat_token = ''
   $jenkins_url = 'http://localhost:8080'
   $version = 'latest'

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -185,6 +185,27 @@ describe 'jenkins_job_builder' do
     end
   end
 
+  context 'explicit timeout value' do
+    describe 'jenkins_job_builder with timeout value specified' do
+      let(:params) {{
+        :timeout => '25'
+      }}
+      let(:facts) {{
+        :osfamily => 'RedHat',
+      }}
+
+      it { should contain_ini_setting('jenkins-jobs timeout').with(
+        'ensure'  => 'present',
+        'path'    => '/etc/jenkins_jobs/jenkins_jobs.ini',
+        'section' => 'jenkins',
+        'setting' => 'timeout',
+        'value'   => 25,
+        'require' => 'File[/etc/jenkins_jobs/jenkins_jobs.ini]'
+      )}
+
+    end
+  end
+
   context 'unsupported operating system' do
     describe 'jenkins_job_builder class without any parameters on Solaris/Nexenta' do
       let(:facts) do


### PR DESCRIPTION
If `timeout` is unset it will remove any existing timeout values in the
config file.

This will hopefully satisfy #26.