### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppet-jenkins_job_builder",
   "version": "2.0.1-rc0",
   "author": "voxpupuli",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "summary": "Module for managing the openstack jenkins_job_builder tool",
   "source": "git://github.com/puppet-community/puppet-jenkins_job_builder.git",
   "project_page": "https://github.com/puppet-community/puppet-jenkins_job_builder",


### PR DESCRIPTION
LICENSE file is MIT, license in metadata.json has been Apache-2.0 for quite some time