### PR TITLE
Rename python-pip to python2-pip

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class jenkins_job_builder::params {
         # This requires the dcaro/jenkins-job-builder repository
         $jjb_packages    = [ 'jenkins-job-builder']
       } else {
-        $python_packages = [ 'python', 'python-devel', 'python-pip', 'PyYAML']
+        $python_packages = [ 'python', 'python-devel', 'python2-pip', 'PyYAML']
         $jjb_packages    = [ 'python-jenkins-job-builder']
       }
     }

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -108,7 +108,7 @@ describe 'jenkins_job_builder' do
         }
       end
 
-      ['python', 'python-pip', 'PyYAML'].each do |dep|
+      ['python', 'python2-pip', 'PyYAML'].each do |dep|
         it { is_expected.to contain_package(dep).with_ensure('present') }
       end
     end


### PR DESCRIPTION
- The `python-pip` package has been removed from EPEL, and replaced with `python2-pip`
- This change renames the package to the new naming