### PR TITLE
Remove virtual package dependency fixes #64

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class jenkins_job_builder::params {
       }
     }
     'debian': {
-      $python_packages = [ 'python', 'python-dev', 'python-pip', 'python-argparse', 'python-yaml' ]
+      $python_packages = [ 'python', 'python-dev', 'python-pip', 'libpython2.7-stdlib', 'python-yaml' ]
       $jjb_packages    = [ 'jenkins-job-builder']
     }
     default: {


### PR DESCRIPTION
python-argparse is a virtual package on Debian and Ubuntu, which is
satisfied by the libpython2.7-stdlib package.

The deb package provider in puppet does not support virtual packages,
resulting in a change every puppet run in the format:

Notice: /Stage[main]/Jenkins_job_builder::Install/Package[python-argparse]/ensure: ensure changed 'purged' to 'present'

See #64 for more info!
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
