### PR TITLE
Remove unused dependency (fixes #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,8 @@ This module is tested on the following platforms:
 
 * CentOS 5
 * CentOS 6
-* Ubuntu 10.04.4
-* Ubuntu 12.04.2
 * Ubuntu 13.10
+* Ubuntu 14.04
 
 It is tested with the OSS version of Puppet only.
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class jenkins_job_builder::params {
       }
     }
     'debian': {
-      $python_packages = [ 'python', 'python-dev', 'python-pip', 'python-argparse', 'python-yaml' ]
+      $python_packages = [ 'python', 'python-dev', 'python-pip', 'python-yaml' ]
       $jjb_packages    = [ 'jenkins-job-builder']
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -28,15 +28,15 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6.0",
-        "7.0"
+        "8.0",
+        "9.0"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     }
   ],


### PR DESCRIPTION
The "python" dependency includes "libpython-stdlib", which includes
"libpython2.7-stdlib", which provides "python-argparse", so this is no
longer needed.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
