### PR TITLE
Allow user/pass to be managed outside Puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ Jenkins instance.
 
 #### `user`
 
-The user used to authenticate to the Jenkins instance.
+The user used to authenticate to the Jenkins instance. (optional)
 
 #### `password`
 
-The password used to authenticate to the Jenkins instance.
+The password used to authenticate to the Jenkins instance. (optional)
 
 #### `timeout`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,10 +20,10 @@
 # A hash of the configuration for all the jobs you want to configure in your Jenkins instance.
 #
 # [*user*]
-# The user used to authenticate to the Jenkins instance.
+# The user used to authenticate to the Jenkins instance. (optional)
 #
 # [*password*]
-# The password used to authenticate to the Jenkins instance.
+# The password used to authenticate to the Jenkins instance. (optional)
 #
 # [*timeout*]
 # The connection timeout (in seconds) to the Jenkins server.
@@ -53,8 +53,8 @@
 class jenkins_job_builder(
   $version                   = $jenkins_job_builder::params::version,
   Hash $jobs                 = $jenkins_job_builder::params::jobs,
-  String $user               = $jenkins_job_builder::params::user,
-  String $password           = $jenkins_job_builder::params::password,
+  Optional[String] $user     = $jenkins_job_builder::params::user,
+  Optional[String] $password = $jenkins_job_builder::params::password,
   Optional[Integer] $timeout = $jenkins_job_builder::params::timeout,
   String $hipchat_token      = $jenkins_job_builder::params::hipchat_token,
   String $jenkins_url        = $jenkins_job_builder::params::jenkins_url,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,8 +10,8 @@
 class jenkins_job_builder::params {
 
   $jobs = {}
-  $user = ''
-  $password = ''
+  $user = undef
+  $password = undef
   $timeout = undef
   $hipchat_token = ''
   $jenkins_url = 'http://localhost:8080'

--- a/spec/classes/jenkins_job_builder_spec.rb
+++ b/spec/classes/jenkins_job_builder_spec.rb
@@ -31,7 +31,7 @@ describe 'jenkins_job_builder' do
             'path'    => '/etc/jenkins_jobs/jenkins_jobs.ini',
             'section' => 'jenkins',
             'setting' => 'user',
-            'value'   => '',
+            'value'   => nil,
             'require' => 'File[/etc/jenkins_jobs/jenkins_jobs.ini]'
           )
         end
@@ -42,7 +42,7 @@ describe 'jenkins_job_builder' do
             'path'    => '/etc/jenkins_jobs/jenkins_jobs.ini',
             'section' => 'jenkins',
             'setting' => 'password',
-            'value'   => '',
+            'value'   => nil,
             'require' => 'File[/etc/jenkins_jobs/jenkins_jobs.ini]'
           )
         end


### PR DESCRIPTION
The `value` field in `ini_setting` is optional. If it's undefined, it will ensure the setting is there, but not modify the value. The benefit to this type of behavior is that I can ensure there is a `password =` line
in the configuration, but allow the user to manually set it outside of Puppet. Future Puppet runs will not modify the user-entered value.

With the default being a blank string, Puppet will wipe out the user's changes every time Puppet runs.

Basically, this allows us to not have to deal with secrets such as the user's API key from within Puppet.

Another use case is if I am building an image for a developer to use- I may not know the username of the future developer, either, but I would still like to set everything else up so it's ready to use after filling in the username and password.